### PR TITLE
Making Usage instructions more complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ npm install mbp -g
 # init your project
 mbp init locomotivemtl/locomotive-boilerplate <directory>
 
+# go to the directory
+cd <directory>
+
 # and start it
 npm start
 ```


### PR DESCRIPTION
If you follow the usage instructions and don't cd into the newly created directory then npm start will fail. So we need to specify going into the directory.