### PR TITLE
Add support for custom task labels

### DIFF
--- a/build/tasks/concats.js
+++ b/build/tasks/concats.js
@@ -17,11 +17,14 @@ import { basename } from 'node:path';
 export default async function concatFiles() {
     loconfig.tasks.concats.forEach(async ({
         includes,
-        outfile
+        outfile,
+        label = null
     }) => {
-        const filename = basename(outfile || 'undefined');
+        if (!label) {
+            label = basename(outfile || 'undefined');
+        }
 
-        const timeLabel = `${filename} concatenated in`;
+        const timeLabel = `${label} concatenated in`;
         console.time(timeLabel);
 
         try {
@@ -33,16 +36,16 @@ export default async function concatFiles() {
             await concat(files, outfile);
 
             if (files.length) {
-                message(`${filename} concatenated`, 'success', timeLabel);
+                message(`${label} concatenated`, 'success', timeLabel);
             } else {
-                message(`${filename} is empty`, 'notice', timeLabel);
+                message(`${label} is empty`, 'notice', timeLabel);
             }
         } catch (err) {
-            message(`Error concatenating ${filename}`, 'error');
+            message(`Error concatenating ${label}`, 'error');
             message(err);
 
             notification({
-                title:   `${filename} concatenation failed 🚨`,
+                title:   `${label} concatenation failed 🚨`,
                 message: `${err.name}: ${err.message}`
             });
         }

--- a/build/tasks/scripts.js
+++ b/build/tasks/scripts.js
@@ -56,11 +56,14 @@ export default async function compileScripts(esBuildOptions = null) {
     loconfig.tasks.scripts.forEach(async ({
         includes,
         outdir = '',
-        outfile = ''
+        outfile = '',
+        label = null
     }) => {
-        const filename = basename(outdir || outfile || 'undefined');
+        if (!label) {
+            label = basename(outdir || outfile || 'undefined');
+        }
 
-        const timeLabel = `${filename} compiled in`;
+        const timeLabel = `${label} compiled in`;
         console.time(timeLabel);
 
         try {
@@ -82,11 +85,11 @@ export default async function compileScripts(esBuildOptions = null) {
                 outfile,
             }));
 
-            message(`${filename} compiled`, 'success', timeLabel);
+            message(`${label} compiled`, 'success', timeLabel);
         } catch (err) {
             // errors managments (already done in esbuild)
             notification({
-                title:   `${filename} compilation failed 🚨`,
+                title:   `${label} compilation failed 🚨`,
                 message: `${err.errors[0].text} in ${err.errors[0].location.file} line ${err.errors[0].location.line}`
             });
         }

--- a/build/tasks/styles.js
+++ b/build/tasks/styles.js
@@ -97,11 +97,12 @@ export default async function compileStyles(sassOptions = null, postcssOptions =
 
     loconfig.tasks.styles.forEach(async ({
         infile,
-        outfile
+        outfile,
+        label = null
     }) => {
-        const name = basename((outfile || 'undefined'), '.css');
+        const filestem = basename((outfile || 'undefined'), '.css');
 
-        const timeLabel = `${name}.css compiled in`;
+        const timeLabel = `${label || `${filestem}.css`} compiled in`;
         console.time(timeLabel);
 
         try {
@@ -132,7 +133,7 @@ export default async function compileStyles(sassOptions = null, postcssOptions =
                 if (result.warnings) {
                     const warnings = result.warnings();
                     if (warnings.length) {
-                        message(`Error processing ${name}.css`, 'warning');
+                        message(`Error processing ${label || `${filestem}.css`}`, 'warning');
                         warnings.forEach((warn) => {
                             message(warn.toString());
                         });
@@ -144,17 +145,17 @@ export default async function compileStyles(sassOptions = null, postcssOptions =
                 await writeFile(outfile, result.css);
 
                 if (result.css) {
-                    message(`${name}.css compiled`, 'success', timeLabel);
+                    message(`${label || `${filestem}.css`} compiled`, 'success', timeLabel);
                 } else {
-                    message(`${name}.css is empty`, 'notice', timeLabel);
+                    message(`${label || `${filestem}.css`} is empty`, 'notice', timeLabel);
                 }
             } catch (err) {
-                message(`Error compiling ${name}.css`, 'error');
+                message(`Error compiling ${label || `${filestem}.css`}`, 'error');
                 message(err);
 
                 notification({
-                    title:   `${name}.css save failed 🚨`,
-                    message: `Could not save stylesheet to ${name}.css`
+                    title:   `${label || `${filestem}.css`} save failed 🚨`,
+                    message: `Could not save stylesheet to ${label || `${filestem}.css`}`
                 });
             }
 
@@ -162,21 +163,21 @@ export default async function compileStyles(sassOptions = null, postcssOptions =
                 try {
                     await writeFile(outfile + '.map', result.map.toString());
                 } catch (err) {
-                    message(`Error compiling ${name}.css.map`, 'error');
+                    message(`Error compiling ${label || `${filestem}.css.map`}`, 'error');
                     message(err);
 
                     notification({
-                        title:   `${name}.css.map save failed 🚨`,
-                        message: `Could not save sourcemap to ${name}.css.map`
+                        title:   `${label || `${filestem}.css.map`} save failed 🚨`,
+                        message: `Could not save sourcemap to ${label || `${filestem}.css.map`}`
                     });
                 }
             }
         } catch (err) {
-            message(`Error compiling ${name}.scss`, 'error');
+            message(`Error compiling ${label || `${filestem}.scss`}`, 'error');
             message(err.formatted || err);
 
             notification({
-                title:   `${name}.scss compilation failed 🚨`,
+                title:   `${label || `${filestem}.scss`} compilation failed 🚨`,
                 message: (err.formatted || `${err.name}: ${err.message}`)
             });
         }

--- a/build/tasks/svgs.js
+++ b/build/tasks/svgs.js
@@ -49,11 +49,14 @@ export default async function compileSVGs(mixerOptions = null) {
 
     loconfig.tasks.svgs.forEach(async ({
         includes,
-        outfile
+        outfile,
+        label = null
     }) => {
-        const filename = basename(outfile || 'undefined');
+        if (!label) {
+            label = basename(outfile || 'undefined');
+        }
 
-        const timeLabel = `${filename} compiled in`;
+        const timeLabel = `${label} compiled in`;
         console.time(timeLabel);
 
         try {
@@ -64,13 +67,13 @@ export default async function compileSVGs(mixerOptions = null) {
 
             await result.write(outfile);
 
-            message(`${filename} compiled`, 'success', timeLabel);
+            message(`${label} compiled`, 'success', timeLabel);
         } catch (err) {
-            message(`Error compiling ${filename}`, 'error');
+            message(`Error compiling ${label}`, 'error');
             message(err);
 
             notification({
-                title:   `${filename} compilation failed 🚨`,
+                title:   `${label} compilation failed 🚨`,
                 message: `${err.name}: ${err.message}`
             });
         }


### PR DESCRIPTION
If ever the basename from the outfile or outdir is an insufficient description.

For the boilerplate's currently available tasks, this feature is not very important but could be for future tasks.
It at least serves as inspiration for custom tasks for specific projects. For example, in two client projects I have a custom `tasks/copies.js` that benefits from a custom label:

<details open>
<summary><strong>Example 1</strong></summary>

```json
"copies": [
    {
        "label": "flatpickr",
        "src": "./node_modules/flatpickr/dist",
        "dest": "./www/assets/admin/flatpickr"
    }
]
```

</details>

<details>
<summary><strong>Example 2</strong></summary>

```json
"concats": [
    {
        "label": "third-parties",
        "includes": [
            "{% paths.scripts.src %}/vendors/*.js"
        ],
        "outfile": "{% paths.scripts.dest %}/vendors.js"
    }
]
```

![Screenshot showing custom task labels](https://user-images.githubusercontent.com/29353/144654066-fbdc65a3-282b-48e2-81f3-098e568b9548.jpg)

</details>