### PR TITLE
Build a single font-face family

### DIFF
--- a/assets/styles/elements/_document.scss
+++ b/assets/styles/elements/_document.scss
@@ -9,7 +9,7 @@
 // 3. Set the default `font-size` and `line-height` for the entire project,
 //    sourced from our default variables.
 
-@include font-faces($font-faces, $font-dir); // [1]
+@include build-font-faces($font-faces, $font-dir); // [1]
 
 html {
     min-height: 100%; // [2]

--- a/assets/styles/elements/_document.scss
+++ b/assets/styles/elements/_document.scss
@@ -9,7 +9,7 @@
 // 3. Set the default `font-size` and `line-height` for the entire project,
 //    sourced from our default variables.
 
-@include build-font-faces($font-faces, $font-dir); // [1]
+@include font-faces($font-faces, $font-dir); // [1]
 
 html {
     min-height: 100%; // [2]

--- a/assets/styles/tools/_fonts.scss
+++ b/assets/styles/tools/_fonts.scss
@@ -16,7 +16,7 @@
         font-display: swap;
         font-family: nth($webfont, 1);
         src: url("#{$dir}#{nth($webfont, 2)}.woff2") format("woff2"),
-             url("#{$dir}#{nth($webfont, 2)}.woff") format("woff");
+            url("#{$dir}#{nth($webfont, 2)}.woff") format("woff");
         font-weight: #{nth($webfont, 3)};
         font-style: #{nth($webfont, 4)};
     }
@@ -31,9 +31,15 @@
 // @param  {String}     $dir      - The webfont directory path.
 // @output The `@font-face` at-rules specifying the custom fonts.
 
-@mixin font-faces($webfonts, $dir) {
-    @each $webfont in $webfonts {
-        @include font-face($webfont, $dir);
+@mixin build-font-faces($webfonts, $dir) {
+    @if (list-separator($webfonts) == "comma") {
+        @each $webfont in $webfonts {
+            @include font-face($webfont, $dir);
+        }
+    } @else if (list-separator($webfonts) == "space") {
+        @include font-face($webfonts, $dir);
+    } @else {
+        @error 'Invalid list separator for $webfonts';
     }
 }
 
@@ -47,8 +53,8 @@
 
 @function ff($font-family) {
     @if not map-has-key($font-families, $font-family) {
-       @error "No font-family found in $font-families map for `#{$font-family}`.";
-   }
+        @error "No font-family found in $font-families map for `#{$font-family}`. Property omitted.";
+    }
 
     $value: map-get($font-families, $font-family);
     @return $value;

--- a/assets/styles/tools/_fonts.scss
+++ b/assets/styles/tools/_fonts.scss
@@ -16,7 +16,7 @@
         font-display: swap;
         font-family: nth($webfont, 1);
         src: url("#{$dir}#{nth($webfont, 2)}.woff2") format("woff2"),
-            url("#{$dir}#{nth($webfont, 2)}.woff") format("woff");
+             url("#{$dir}#{nth($webfont, 2)}.woff") format("woff");
         font-weight: #{nth($webfont, 3)};
         font-style: #{nth($webfont, 4)};
     }
@@ -31,7 +31,7 @@
 // @param  {String}     $dir      - The webfont directory path.
 // @output The `@font-face` at-rules specifying the custom fonts.
 
-@mixin build-font-faces($webfonts, $dir) {
+@mixin font-faces($webfonts, $dir) {
     @if (list-separator($webfonts) == "comma") {
         @each $webfont in $webfonts {
             @include font-face($webfont, $dir);


### PR DESCRIPTION
## Proposed changes

To be able to build a single family of font-faces, 
It's must to check whether the `$font-faces` list is separated by `spaces` or by `commas`.

---

For example:
```scss
$font-faces: (
    "Webfont Sans" "webfont-sans_regular" 400 normal
)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

---

## Editorial note

1. Fixes support for building a single font family using `$font-faces` by fixing iteration of that global variable in the `font-faces` mixin.

   Because Sass accepts commas, spaces, and slashes as list separators, when `$font-faces` contained only one family (`<font-name> <font-file-basename> <font-weight> <font-style>`), it would iterate each segment of the family instead of the tuple as a whole.