### PR TITLE
Feature/scss functions

### DIFF
--- a/assets/styles/tools/_functions.scss
+++ b/assets/styles/tools/_functions.scss
@@ -184,5 +184,5 @@ $context: 'frontend' !default;
  * @return {Number} - Clamped font size based on breakpoint
  */
 @function responsive-type($min-size, $max-size, $breakpoint) {
-    @return clamp($min-size, calc(#{strip-unit($max-size)}/#{$breakpoint} * 100vw), $max-size)
+    @return clamp($min-size, calc(#{strip-unit($max-size)}/#{strip-unit(#{$breakpoint}) * 100vw), $max-size);
 }

--- a/assets/styles/tools/_functions.scss
+++ b/assets/styles/tools/_functions.scss
@@ -184,5 +184,5 @@ $context: 'frontend' !default;
  * @return {Number} - Clamped font size based on breakpoint
  */
 @function responsive-type($min-size, $max-size, $breakpoint) {
-    @return clamp($min-size, calc(#{strip-unit($max-size)}/#{strip-unit(#{$breakpoint}) * 100vw), $max-size);
+    @return clamp($min-size, calc(#{strip-unit($max-size)}/#{strip-unit(#{$breakpoint})} * 100vw), $max-size);
 }

--- a/assets/styles/tools/_functions.scss
+++ b/assets/styles/tools/_functions.scss
@@ -138,51 +138,54 @@
     @return ('frontend' == $context);
 }
 
-$context: 'frontend' !default;
-
-
-
-/**
- * Calculate grid space
- * @param  {number} $number The percentage spacer
- * @return {number} in calc
- */
-@function grid-space($percentage, $offset: 0) {
-    // @return calc(#{$percentage} * (100vw - 2 * var(--grid-margin)) - (1 - #{$percentage}) * var(--grid-gutter) + #{$offset} * var(--grid-gutter));
-    @return calc(#{$percentage} * (100vw - 2 * var(--grid-margin, 0px)) - (1 - #{$percentage}) * var(--grid-gutter, 0px) + #{$offset} * var(--grid-gutter, 0px));
+// Returns calculation of a percentage of the grid cell width
+// with optional inset of grid gutter.
+//
+// ```scss
+// .c-box {
+//     width: grid-space(6/12);
+//     margin-left: grid-space(1/12, 1);
+// }
+// ```
+//
+// @param  {number} $number - The percentage spacer
+// @param  {number} $inset  - The grid gutter inset
+// @return {function<number>}
+@function grid-space($percentage, $inset: 0) {
+    @return calc(#{$percentage} * (100vw - 2 * var(--grid-margin, 0px)) - (1 - #{$percentage}) * var(--grid-gutter, 0px) + #{$inset} * var(--grid-gutter, 0px));
 }
 
-
-/**
- * Calculate vh percentage from number
- * @param  {number} $number The percentage number
- * @return {number} in vh
- */
+// Returns calculation of a percentage of the viewport height.
+//
+// ```scss
+// .c-box {
+//     height: vh(100);
+// }
+// ```
+//
+// @param  {number} $number - The percentage number
+// @return {function<number>} in vh
 @function vh($number) {
     @return calc(#{$number} * var(--vh, 1vh));
 }
 
-/**
- * Remove the unit of a length
- * @param {Number} $number - Number to remove unit from
- * @return {Number} - Unitless number
- */
-@function strip-unit($number) {
-  @if type-of($number) == 'number' and not unitless($number) {
-    @return $number / ($number * 0 + 1);
-  }
-
-  @return $number;
-}
-
-
-/**
- * Responsive font size
- * @param {Number} $min-size - Minimum font size in pixel
- * @param {Number} $max-size - Maximum font size in pixel
- * @param {Number} $breakpoint - The breakpoint
- * @return {Number} - Clamped font size based on breakpoint
- */
+// Returns clamp of calculated preferred responsive font size
+// within a font size and breakpoint range.
+//
+// ```scss
+// .c-heading.-h1 {
+//     font-size: responsive-type(30px, 60px, 1800);
+// }
+//
+// .c-heading.-h2 {
+//     font-size: responsive-type(20px, 40px, $from-big);
+// }
+// ```
+//
+// @param  {number} $min-size   - Minimum font size in pixels.
+// @param  {number} $max-size   - Maximum font size in pixels.
+// @param  {number} $breakpoint - Maximum breakpoint.
+// @return {function<number, function<number>, number>}
 @function responsive-type($min-size, $max-size, $breakpoint) {
     @return clamp($min-size, calc(#{strip-unit($max-size)}/#{strip-unit(#{$breakpoint})} * 100vw), $max-size);
 }

--- a/assets/styles/tools/_functions.scss
+++ b/assets/styles/tools/_functions.scss
@@ -139,3 +139,50 @@
 }
 
 $context: 'frontend' !default;
+
+
+
+/**
+ * Calculate grid space
+ * @param  {number} $number The percentage spacer
+ * @return {number} in calc
+ */
+@function grid-space($percentage, $offset: 0) {
+    // @return calc(#{$percentage} * (100vw - 2 * var(--grid-margin)) - (1 - #{$percentage}) * var(--grid-gutter) + #{$offset} * var(--grid-gutter));
+    @return calc(#{$percentage} * (100vw - 2 * var(--grid-margin, 0px)) - (1 - #{$percentage}) * var(--grid-gutter, 0px) + #{$offset} * var(--grid-gutter, 0px));
+}
+
+
+/**
+ * Calculate vh percentage from number
+ * @param  {number} $number The percentage number
+ * @return {number} in vh
+ */
+@function vh($number) {
+    @return calc(#{$number} * var(--vh, 1vh));
+}
+
+/**
+ * Remove the unit of a length
+ * @param {Number} $number - Number to remove unit from
+ * @return {Number} - Unitless number
+ */
+@function strip-unit($number) {
+  @if type-of($number) == 'number' and not unitless($number) {
+    @return $number / ($number * 0 + 1);
+  }
+
+  @return $number;
+}
+
+
+/**
+ * Responsive font size
+ * @param {Number} $min-size - Minimum font size in pixel
+ * @param {Number} $max-size - Maximum font size in pixel
+ * @param {Number} $breakpoint - The breakpoint
+ * @return {Number} - Clamped font size based on breakpoint
+ */
+@function responsive-type($min-size, $max-size, $breakpoint) {
+    @return clamp($min-size, calc(#{strip-unit($max-size)}/#{$breakpoint} * 100vw), $max-size)
+}

--- a/assets/styles/tools/_maths.scss
+++ b/assets/styles/tools/_maths.scss
@@ -2,13 +2,18 @@
 // Tools / Maths
 // ==========================================================================
 
-// Removes the unit from the given number.
+// Remove the unit of a length
 //
-// @param  {number} $number The number to strip.
-// @return {number}
+// @param {Number} $number Number to remove unit from
+// @return {function<number>}
+@function strip-unit($number) {
+    @if type-of($value) != "number" {
+        @error "Invalid `#{type-of($value)}` type. Choose a number type instead.";
+    } @else if type-of($number) == 'number' and not unitless($number) {
+        @return $number / ($number * 0 + 1);
+    }
 
-@function strip-units($number) {
-    @return $number / ($number * 0 + 1);
+    @return $number;
 }
 
 // Returns the square root of the given number.


### PR DESCRIPTION
Add useful SCSS functions:

—

`grid-space()`
Return value based on grid cell width with possible offset of grid gutter

**Usage:**
```
.box {
    width: grid-space(6/12);
    margin-left: grid-space(1/12, 1);
}
```

—

`vh()`
Return value based of vh, default css vh if no overwrite (by javascript on mobile for example)

**Usage:**
```
.box {
    height: vh(100);
}
```

—

`strip-unit()`
Return a value without unit (used for other function)

—

`responsive-type()`
Clamp min/max px value with a max breakpoint, useful for responsive font sizes

**Usage:**
```
.c-heading.-h1 {
    font-size: responsive-type(30px, 60px, 1800);
}
.c-heading.-h2 {
    font-size: responsive-type(20px, 40px, $from-big);
}
```
**Comment:**
Breakpoint value can be in px or plain number.
