### PR TITLE
Replace fractions with math.div in scss files

### DIFF
--- a/assets/styles/objects/_icons.scss
+++ b/assets/styles/objects/_icons.scss
@@ -32,7 +32,7 @@
     vertical-align: middle;
 
     svg {
-        --icon-height: calc(var(--icon-width) * (1 / (var(--icon-ratio))));
+        --icon-height: calc(var(--icon-width) * math.div(1, (var(--icon-ratio))));
 
         display: block;
         width: var(--icon-width);

--- a/assets/styles/tools/_family.scss
+++ b/assets/styles/tools/_family.scss
@@ -147,7 +147,7 @@
 // @param {number} $num - id of the child
 
 @mixin middle($num) {
-    &:nth-child(#{round($num / 2)}) {
+    &:nth-child(#{round(math.div($num, 2))}) {
         @content;
     }
 }

--- a/assets/styles/tools/_maths.scss
+++ b/assets/styles/tools/_maths.scss
@@ -8,7 +8,7 @@
 // @return {number}
 
 @function strip-units($number) {
-    @return $number / ($number * 0 + 1);
+    @return math.div($number, ($number * 0 + 1));
 }
 
 // Returns the square root of the given number.
@@ -21,7 +21,7 @@
     $value: $x;
 
     @for $i from 1 through 10 {
-        $value: $x - ($x * $x - abs($number)) / (2 * $x);
+        $value: $x - math.div(($x * $x - abs($number)), (2 * $x));
         $x: $value;
     }
 
@@ -43,7 +43,7 @@
         }
     } @else if $exp < 0 {
         @for $i from 1 through -$exp {
-            $value: $value / $number;
+            $value: math.div($value, $number);
         }
     }
 
@@ -88,7 +88,7 @@
 
     // If the angle has `deg` as unit, convert to radians.
     @if ($unit == deg) {
-        @return $angle / 180 * pi();
+        @return math.div($angle, 180) * pi();
     }
 
     @return $angle;
@@ -104,7 +104,7 @@
     $angle: rad($angle);
 
     @for $i from 0 through 10 {
-        $sin: $sin + pow(-1, $i) * pow($angle, (2 * $i + 1)) / fact(2 * $i + 1);
+        $sin: $sin + pow(-1, $i) * math.div(pow($angle, (2 * $i + 1)), fact(2 * $i + 1));
     }
 
     @return $sin;
@@ -120,7 +120,7 @@
     $angle: rad($angle);
 
     @for $i from 0 through 10 {
-        $cos: $cos + pow(-1, $i) * pow($angle, 2 * $i) / fact(2 * $i);
+        $cos: $cos + pow(-1, $i) * math.div(pow($angle, 2 * $i), fact(2 * $i));
     }
 
     @return $cos;
@@ -132,5 +132,5 @@
 // @return {number}
 
 @function tan($angle) {
-    @return sin($angle) / cos($angle);
+    @return math.div(sin($angle), cos($angle));
 }

--- a/assets/styles/tools/_mixins.scss
+++ b/assets/styles/tools/_mixins.scss
@@ -51,7 +51,7 @@
     font-size: rem($font-size) $important;
 
     @if ($line-height == "auto") {
-        line-height: ceil($font-size / $line-height) * ($line-height / $font-size) $important;
+        line-height: ceil(math.div($font-size, $line-height)) * math.div($line-height, $font-size) $important;
     }
     @else {
         @if (type-of($line-height) == number or $line-height == "inherit" or $line-height == "normal") {

--- a/assets/styles/tools/_widths.scss
+++ b/assets/styles/tools/_widths.scss
@@ -58,7 +58,7 @@ $breakpoint-delimiter: \@ !default;
         @for $numerator from 1 through $denominator {
             // Build a class in the format `.u-3/4[@<breakpoint>]`.
             .u-#{$numerator}#{$fractions-delimiter}#{$denominator}#{$breakpoint} {
-                width: ($numerator / $denominator) * 100% $important;
+                width: math.div($numerator, $denominator) * 100% $important;
             }
 
             @if ($widths-offsets == true) {
@@ -66,13 +66,13 @@ $breakpoint-delimiter: \@ !default;
                 .u-push-#{$numerator}#{$fractions-delimiter}#{$denominator}#{$breakpoint} {
                     position: relative $important;
                     right: auto $important;
-                    left: ($numerator / $denominator) * 100% $important;
+                    left: math.div($numerator, $denominator) * 100% $important;
                 }
 
                 // Build a class in the format `.u-pull-5/6[@<breakpoint>]`.
                 .u-pull-#{$numerator}#{$fractions-delimiter}#{$denominator}#{$breakpoint} {
                     position: relative $important;
-                    right: ($numerator / $denominator) * 100% $important;
+                    right: math.div($numerator, $denominator) * 100% $important;
                     left: auto $important;
                 }
             }


### PR DESCRIPTION
Standardise the use of div with Dart SASS
Replace every instance of `x / y` to `math.div(x, y)` in the code base