### PR TITLE
Add dedicated SVG sprite folder

### DIFF
--- a/loconfig.json
+++ b/loconfig.json
@@ -15,7 +15,7 @@
             "dest": "./www/assets/scripts"
         },
         "svgs": {
-            "src": "./assets/images/sprite",
+            "src": "./assets/svgs",
             "dest": "./www/assets/images"
         },
         "views": {


### PR DESCRIPTION
## What
Add a dedicated `svgs` folder at the root of the assets

## Why
Every build task is using a folder at the root of assets.
There is no need to use a nested folder in `assets/images/sprite` as the `assets/images` folder is only used for the svg sprite.
We may want to delete the `assets/images` folder.
