### PR TITLE
Add default text dedicated file

### DIFF
--- a/assets/styles/components/_text.scss
+++ b/assets/styles/components/_text.scss
@@ -1,0 +1,53 @@
+// ==========================================================================
+// Components / Texts
+// ==========================================================================
+
+// Font sizes
+// ==========================================================================
+:root {
+    --font-size-body-regular:   #{responsive-value(15px, 17px, $from-lg)};
+    --font-size-body-medium:    #{responsive-value(18px, 23px, $from-lg)};
+    --font-size-body-small:     #{responsive-value(13px, 16px, $from-lg)};
+}
+
+// Mixins
+// ==========================================================================
+@mixin text {
+    font-family: ff('sans');
+}
+
+@mixin body-regular {
+    font-size: var(--font-size-body-regular);
+    font-weight: $font-weight-normal;
+    line-height: 1.2;
+}
+
+@mixin body-medium {
+    font-size: var(--font-size-body-medium);
+    font-weight: $font-weight-normal;
+    line-height: 1.2;
+}
+
+@mixin body-small {
+    font-size: var(--font-size-body-small);
+    font-weight: $font-weight-normal;
+    line-height: 1.2;
+}
+
+// Styles
+// ==========================================================================
+.c-text {
+    @include text;
+
+    &.-body-regular {
+        @include body-regular;
+    }
+
+    &.-body-medium {
+        @include body-medium;
+    }
+
+    &.-body-small {
+        @include body-small;
+    }
+}

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -54,6 +54,7 @@
 // ==========================================================================
 
 @import "components/heading";
+@import "components/text";
 @import "components/button";
 @import "components/form";
 


### PR DESCRIPTION
Following the same logic as `_heading.scss`, we might want to add a dedicated `_text.scss` file by default, using the same structure:
- Font sizes using css variables on the root
- Mixins with specific styles so we can use these anywhere else if needed
- Styles application

These default names and values could be overwrited if needed.