### PR TITLE
Remove babel-polyfill

### DIFF
--- a/www/form.html
+++ b/www/form.html
@@ -96,8 +96,6 @@
             </div>
         </div>
 
-        <script nomodule src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.6.0/polyfill.min.js" crossorigin="anonymous"></script>
-
         <script src="assets/scripts/vendors.js" defer></script>
         <script src="assets/scripts/app.js" defer></script>
     </body>

--- a/www/grid.html
+++ b/www/grid.html
@@ -83,9 +83,6 @@
         </div>
     </div>
 
-    <script nomodule src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.6.0/polyfill.min.js"
-        crossorigin="anonymous"></script>
-
     <script src="assets/scripts/vendors.js" defer></script>
     <script src="assets/scripts/app.js" defer></script>
 </body>

--- a/www/images.html
+++ b/www/images.html
@@ -122,8 +122,6 @@
             </div>
         </div>
 
-        <script nomodule src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.6.0/polyfill.min.js" crossorigin="anonymous"></script>
-
         <script src="assets/scripts/vendors.js" defer></script>
         <script src="assets/scripts/app.js" defer></script>
     </body>

--- a/www/index.html
+++ b/www/index.html
@@ -69,9 +69,6 @@
         </div>
     </div>
 
-    <script nomodule src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.6.0/polyfill.min.js"
-        crossorigin="anonymous"></script>
-
     <script src="assets/scripts/vendors.js" defer></script>
     <script src="assets/scripts/app.js" defer></script>
 </body>


### PR DESCRIPTION
All features are suported by modern browsers.

Can be restored if ever needed to support older browsers.