### PR TITLE
Remove svg4everybody

### DIFF
--- a/assets/scripts/globals.js
+++ b/assets/scripts/globals.js
@@ -1,4 +1,3 @@
-import svg4everybody from 'svg4everybody';
 import { ENV } from './config';
 
 // Dynamic imports for development mode only
@@ -11,11 +10,6 @@ let gridHelper;
 })();
 
 export default function () {
-    /**
-     * Use external SVG spritemaps
-     */
-    svg4everybody();
-
     /**
      * Add grid helper
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
             "dependencies": {
                 "locomotive-scroll": "^5.0.0-beta.21",
                 "modujs": "^1.4.2",
-                "modularload": "^1.2.6",
-                "svg4everybody": "^2.1.9"
+                "modularload": "^1.2.6"
             },
             "devDependencies": {
                 "autoprefixer": "^10.4.20",
@@ -5030,14 +5029,6 @@
             "dev": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/svg4everybody": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/svg4everybody/-/svg4everybody-2.1.9.tgz",
-            "integrity": "sha512-AS9WORVV/vk520ZHxGTlQzyDBizp/h6WyAYUbKhze/kwvQr43DwJpkIIPBomsUyKqN7N+h1deF92N9PmW+o+9A==",
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
         "node_modules/tiny-glob": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "dependencies": {
         "locomotive-scroll": "^5.0.0-beta.21",
         "modujs": "^1.4.2",
-        "modularload": "^1.2.6",
-        "svg4everybody": "^2.1.9"
+        "modularload": "^1.2.6"
     },
     "devDependencies": {
         "autoprefixer": "^10.4.20",


### PR DESCRIPTION
I think its time to remove this JS dependency.

SVG External Content is supported by all major browsers.
The dependency itself has not been updated since 2017.
The last issue reported was for MS IE 11 in 2020.

If ever support is needed for an obsolete browser, the dependency can be added on that project.

---

> MS IE9-MS Edge 12, Safari 5.1-6, and UCWeb 11 do not support [referencing external files](https://css-tricks.com/svg-use-external-source/) via `<use xlink:href>`.

https://caniuse.com/svg